### PR TITLE
Cannot import name LOOKUP_SEP

### DIFF
--- a/mongoadmin/options.py
+++ b/mongoadmin/options.py
@@ -11,7 +11,8 @@ from django.core.paginator import Paginator
 from django.db import models, transaction, router
 from django.db.models.related import RelatedObject
 from django.db.models.fields import BLANK_CHOICE_DASH, FieldDoesNotExist
-from django.db.models.sql.constants import LOOKUP_SEP, QUERY_TERMS
+from django.db.models.constants import LOOKUP_SEP
+from django.db.models.sql.constants import QUERY_TERMS
 from django.http import Http404, HttpResponse, HttpResponseRedirect
 from django.shortcuts import get_object_or_404, render_to_response
 from django.utils.decorators import method_decorator

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ def convert_readme():
     return open('README.txt').read()
 
 setup(name='mongoadmin',
-    version='0.1.3',
+    version='0.1.4',
     description="A replacement for django's admin that works with mongodb.",
     author='Jan Schrewe',
     author_email='jan@schafproductions.com',


### PR DESCRIPTION
mportError: cannot import name LOOKUP_SEP

options.py line 14

moved from django.db.models.sql.constants to django.db.models.constants
