### PR TITLE
Removed unnecessary label setup.

### DIFF
--- a/mongoadmin/options.py
+++ b/mongoadmin/options.py
@@ -40,7 +40,7 @@ def formfield(field, form_class=None, **kwargs):
     """
     Returns a django.forms.Field instance for this database Field.
     """
-    defaults = {'required': field.required, 'label': forms.forms.pretty_name(field.name)}
+    defaults = {'required': field.required}
     if field.default is not None:
         if isinstance(field.default, collections.Callable):
             defaults['initial'] = field.default()


### PR DESCRIPTION
Since label is set in fieldgenerator in mongodbforms and is overridden with sent kwargs: it was always set by field name.
First, this assignment is not needed due to the fact, that mongodbforms field generator creates label based on field verbose_name or name.
Second, this assignment makes it impossible to have field labeled by verbose_name.